### PR TITLE
UNG-1063 Backend public key handling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(COMPONENT_REQUIRES
         ubirch-esp32-api-http
         )
 
-set(COMPONENT_PRIV_REQUIRES )
+set(COMPONENT_PRIV_REQUIRES
+        mbedtls
+        )
 
 register_component()

--- a/key_handling.c
+++ b/key_handling.c
@@ -156,12 +156,19 @@ void register_keys(void) {
     }
 
     // send the data
-    err = ubirch_send(CONFIG_UBIRCH_BACKEND_KEY_SERVER_URL, UUID, sbuf->data, sbuf->size, NULL);
-    if(err != ESP_OK) {
-        ESP_LOGE(TAG, "unable to send registration");
+    // TODO: verify response
+    int http_status;
+    if (ubirch_send(CONFIG_UBIRCH_BACKEND_KEY_SERVER_URL, UUID, sbuf->data, sbuf->size, &http_status, NULL, NULL)
+            == UBIRCH_SEND_OK) {
+        if (http_status == 200) {
+            ESP_LOGI(TAG, "successfull sent registration");
+        } else {
+            ESP_LOGE(TAG, "unable to send registration");
+        }
+    } else {
+        ESP_LOGE(TAG, "error while sending registration");
     }
     msgpack_sbuffer_free(sbuf);
-    ESP_LOGI(TAG, "successfull sent registration");
 }
 
 

--- a/key_handling.c
+++ b/key_handling.c
@@ -49,9 +49,6 @@ unsigned char ed25519_public_key[crypto_sign_PUBLICKEYBYTES] = {};
 // define buffer for server public key
 unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES] = {};
 
-// length of base64 string is ceil(number_of_bytes / 3) * 4 (if number_of_bytes is > 0)
-#define PUBLICKEY_BASE64_STRING_LENGTH ((1 + ((crypto_sign_PUBLICKEYBYTES - 1) / 3)) * 4)
-
 
 /*!
  * Read the Key values from memory

--- a/key_handling.c
+++ b/key_handling.c
@@ -229,7 +229,7 @@ esp_err_t set_backend_public_key(const char* keybase64string) {
         return ESP_FAIL;
     }
     ESP_LOGI(TAG, "setting backend public key");
-    ESP_LOG_BUFFER_HEXDUMP("key", server_pub_key, len, ESP_LOG_INFO);
+    ESP_LOG_BUFFER_HEXDUMP("key", server_pub_key, crypto_sign_PUBLICKEYBYTES, ESP_LOG_INFO);
     //store the public key
     esp_err_t err = kv_store("key_storage", "server_key", server_pub_key, crypto_sign_PUBLICKEYBYTES);
     if (memory_error_check(err)) return err;

--- a/key_handling.c
+++ b/key_handling.c
@@ -44,13 +44,8 @@ extern unsigned char UUID[16];
 unsigned char ed25519_secret_key[crypto_sign_SECRETKEYBYTES] = {};
 unsigned char ed25519_public_key[crypto_sign_PUBLICKEYBYTES] = {};
 
-// actual ubirch key server public key
-const unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES] = {
-        0xa2, 0x40, 0x3b, 0x92, 0xbc, 0x9a, 0xdd, 0x36,
-        0x5b, 0x3c, 0xd1, 0x2f, 0xf1, 0x20, 0xd0, 0x20,
-        0x64, 0x7f, 0x84, 0xea, 0x69, 0x83, 0xf9, 0x8b,
-        0xc4, 0xc8, 0x7e, 0x0f, 0x4b, 0xe8, 0xcd, 0x66
-};
+// define buffer for server public key
+unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES] = {};
 
 
 /*!

--- a/key_handling.c
+++ b/key_handling.c
@@ -236,6 +236,9 @@ esp_err_t set_backend_public_key(const char* keybase64string) {
 
 
 esp_err_t get_backend_public_key(char* buffer, const size_t buffer_size) {
+    if (load_backend_key() != ESP_OK) {
+        return ESP_FAIL;
+    }
     unsigned int outputlen = 0;
     switch (mbedtls_base64_encode((unsigned char*)buffer, buffer_size, &outputlen, server_pub_key, crypto_sign_PUBLICKEYBYTES)) {
         case 0:

--- a/key_handling.c
+++ b/key_handling.c
@@ -236,3 +236,19 @@ esp_err_t set_backend_public_key(const char* keybase64string) {
 
     return err;
 }
+
+
+esp_err_t get_backend_public_key(char* buffer, const size_t buffer_size) {
+    unsigned int outputlen = 0;
+    switch (mbedtls_base64_encode((unsigned char*)buffer, buffer_size, &outputlen, server_pub_key, crypto_sign_PUBLICKEYBYTES)) {
+        case 0:
+            break;
+        case MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL:
+            ESP_LOGE(TAG, "buffer size too small");
+            return ESP_FAIL;
+        default:
+            ESP_LOGE(TAG, "error encoding to base64");
+            return ESP_FAIL;
+    }
+    return ESP_OK;
+}

--- a/key_handling.h
+++ b/key_handling.h
@@ -28,11 +28,13 @@
 #define KEY_HANDLING_H
 
 #include <string.h>
+#include "ubirch_ed25519.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+extern unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES];
 
 /*!  
  * Create a new signature Key pair.

--- a/key_handling.h
+++ b/key_handling.h
@@ -34,6 +34,9 @@
 extern "C" {
 #endif
 
+// length of base64 string is ceil(number_of_bytes / 3) * 4 (if number_of_bytes is > 0)
+#define PUBLICKEY_BASE64_STRING_LENGTH ((1 + ((crypto_sign_PUBLICKEYBYTES - 1) / 3)) * 4)
+
 extern unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES];
 
 /*!  

--- a/key_handling.h
+++ b/key_handling.h
@@ -76,6 +76,16 @@ esp_err_t set_backend_public_key(const char* keybase64string);
  */
 esp_err_t set_backend_default_public_key(void);
 
+/*!
+ * Get backend public key from flash in base64 format.
+ *
+ * @param buffer to write resulting string to
+ * @param buffer_size size of provided buffer
+ * @return ESP_OK
+ * @return ESP_FAIL
+ */
+esp_err_t get_backend_public_key(char* buffer, const size_t buffer_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/key_handling.h
+++ b/key_handling.h
@@ -67,16 +67,16 @@ void check_key_status(void);
  * Set backend public key.
  *
  * @param key The key in base64 string format, '\0' terminated
- * @return ESP_OK
- * @return ESP_FAIL
+ * @return ESP_OK if key was set successfully
+ *         ESP_FAIL if any error occured
  */
 esp_err_t set_backend_public_key(const char* keybase64string);
 
 /*!
  * Set backend default public key given by Kconfig value CONFIG_UBIRCH_BACKEND_PUBLIC_KEY.
  *
- * @return ESP_OK
- * @return ESP_FAIL
+ * @return ESP_OK if default key was set successfully
+ *         ESP_FAIL if any error occured
  */
 esp_err_t set_backend_default_public_key(void);
 
@@ -85,8 +85,8 @@ esp_err_t set_backend_default_public_key(void);
  *
  * @param buffer to write resulting string to
  * @param buffer_size size of provided buffer
- * @return ESP_OK
- * @return ESP_FAIL
+ * @return ESP_OK if backened key was written to buffer successfully
+ *         ESP_FAIL if any error occured
  */
 esp_err_t get_backend_public_key(char* buffer, const size_t buffer_size);
 

--- a/key_handling.h
+++ b/key_handling.h
@@ -59,6 +59,23 @@ void register_keys(void);
  */
 void check_key_status(void);
 
+/*!
+ * Set backend public key.
+ *
+ * @param key The key in base64 string format, '\0' terminated
+ * @return ESP_OK
+ * @return ESP_FAIL
+ */
+esp_err_t set_backend_public_key(const char* keybase64string);
+
+/*!
+ * Set backend default public key given by Kconfig value CONFIG_UBIRCH_BACKEND_PUBLIC_KEY.
+ *
+ * @return ESP_OK
+ * @return ESP_FAIL
+ */
+esp_err_t set_backend_default_public_key(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/key_handling.h
+++ b/key_handling.h
@@ -34,8 +34,9 @@
 extern "C" {
 #endif
 
-// length of base64 string is ceil(number_of_bytes / 3) * 4 (if number_of_bytes is > 0)
-#define PUBLICKEY_BASE64_STRING_LENGTH ((1 + ((crypto_sign_PUBLICKEYBYTES - 1) / 3)) * 4)
+// length of base64 string is ceil(number_of_bytes / 3) * 4
+// to get ceil for value / 3 (value >= 0) we use (value + 2) / 3
+#define PUBLICKEY_BASE64_STRING_LENGTH (((crypto_sign_PUBLICKEYBYTES + 2) / 3) * 4)
 
 extern unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES];
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+idf_component_register(
+    SRC_DIRS "."
+    INCLUDE_DIRS ".."
+    REQUIRES
+        unity
+        ubirch-protocol
+        ubirch-esp32-storage
+        ubirch-esp32-api-http
+    PRIV_REQUIRES
+        mbedtls)

--- a/test/test.c
+++ b/test/test.c
@@ -60,3 +60,25 @@ TEST_CASE("reject broken keys", "[key handling]") {
     // try to store base64 string that encodes key of wrong length
     TEST_ASSERT_EQUAL_INT(ESP_FAIL, set_backend_public_key("42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPAEHC5p=="));
 }
+
+TEST_CASE("get backend key in base64 format", "[key handling]") {
+    // store some key
+    const char input[] = "42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPAEHC5pA=";
+    printf("%s\n", input);
+    TEST_ASSERT_EQUAL_INT(ESP_OK, set_backend_public_key(input));
+    // load in base64 format, buffer needs space for terminating character
+    char buffer[PUBLICKEY_BASE64_STRING_LENGTH + 1];
+    TEST_ASSERT_EQUAL_INT(ESP_OK, get_backend_public_key((char*)buffer, sizeof(buffer)));
+    TEST_ASSERT_EQUAL_STRING(input, buffer);
+    printf("%s\n", buffer);
+}
+
+TEST_CASE("try to get backend key in base64 format into buffer that is too small", "[key handling]") {
+    // store some key
+    const char input[] = "42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPAEHC5pA=";
+    TEST_ASSERT_EQUAL_INT(ESP_OK, set_backend_public_key(input));
+    // with buffer too small
+    char buffer2[PUBLICKEY_BASE64_STRING_LENGTH];
+    TEST_ASSERT_EQUAL_INT(ESP_FAIL, get_backend_public_key((char*)buffer2, sizeof(buffer2)));
+    printf("%s\n", buffer2);
+}

--- a/test/test.c
+++ b/test/test.c
@@ -1,0 +1,62 @@
+#include "unity.h"
+#include <string.h>
+//#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+#include <esp_log.h>
+#include <mbedtls/base64.h>
+
+// include compilation unit to be able to test static functions
+#include "key_handling.c"
+
+// dummy uuid
+unsigned char UUID[16] = {0};
+
+
+TEST_CASE("store and load", "[key handling]") {
+    // NOTE: if you want to test the `create_keys` function make sure you don't have anything in the flash you might
+    //       need, then erase it with the help of idftool.py
+    if (load_keys() != ESP_OK) {
+        create_keys();
+    }
+    TEST_ASSERT_EQUAL_INT(ESP_OK, load_keys());
+}
+
+
+TEST_CASE("store and load default backend key", "[key handling]") {
+    // store key from default configuration
+    TEST_ASSERT_EQUAL_INT(ESP_OK, set_backend_default_public_key());
+    TEST_ASSERT_EQUAL_INT(ESP_OK, load_backend_key());
+
+    // load from base64 key from CONFIG_UBIRCH_BACKEND_PUBLIC_KEY
+    unsigned char data[crypto_sign_PUBLICKEYBYTES] = {0};
+    const char input[] = CONFIG_UBIRCH_BACKEND_PUBLIC_KEY;
+    size_t len = 0;
+    TEST_ASSERT_EQUAL_INT(0, mbedtls_base64_decode(data, crypto_sign_PUBLICKEYBYTES, &len,
+                (const unsigned char*)input, strlen(input)));
+    TEST_ASSERT_EQUAL_INT(crypto_sign_PUBLICKEYBYTES, len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(data, server_pub_key, crypto_sign_PUBLICKEYBYTES);
+}
+
+TEST_CASE("store and load backend key", "[key handling]") {
+    // store some key
+    const char input[] = "42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPAEHC5pA=";
+    TEST_ASSERT_EQUAL_INT(ESP_OK, set_backend_public_key(input));
+    TEST_ASSERT_EQUAL_INT(ESP_OK, load_backend_key());
+
+    // load from base64 key from CONFIG_UBIRCH_BACKEND_PUBLIC_KEY
+    unsigned char data[crypto_sign_PUBLICKEYBYTES] = {0};
+    size_t len = 0;
+    TEST_ASSERT_EQUAL_INT(0, mbedtls_base64_decode(data, crypto_sign_PUBLICKEYBYTES, &len,
+                (const unsigned char*)input, strlen(input)));
+    TEST_ASSERT_EQUAL_INT(crypto_sign_PUBLICKEYBYTES, len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(data, server_pub_key, crypto_sign_PUBLICKEYBYTES);
+}
+
+TEST_CASE("reject broken keys", "[key handling]") {
+    // try to store key of wrong length
+    TEST_ASSERT_EQUAL_INT(ESP_FAIL, set_backend_public_key("42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPApA="));
+    TEST_ASSERT_EQUAL_INT(ESP_FAIL, set_backend_public_key("42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPAE32425pA="));
+    // try to store broken base64 key
+    TEST_ASSERT_EQUAL_INT(ESP_FAIL, set_backend_public_key("42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPA!HC5pA="));
+    // try to store base64 string that encodes key of wrong length
+    TEST_ASSERT_EQUAL_INT(ESP_FAIL, set_backend_public_key("42ABCDbAKFrwF3AJOBgwxGzsAl0B2GCF51pPAEHC5p=="));
+}


### PR DESCRIPTION
This PR
* **removes** unused `server_pub_key` initialization
* **adds** functions to load a backend public key from base64 string (as parameter or as Kconfig configuration value) into `server_pub_key`
* **adds** function to get base64 string representation of server_pub_key
* **changes** `check_key_status` additionally loads backend public key from flash if available otherwise stores Kconfig configuration value first
* **adds** some tests