### PR TITLE
Feature/ung 3385/key update

### DIFF
--- a/key_handling.c
+++ b/key_handling.c
@@ -38,10 +38,15 @@
 
 #include "key_handling.h"
 
-#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+//#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
 
-#define KEY_LIFETIME_IN_SECONDS (31536000) // one year
-#define KEY_UPDATE_BEFORE_EXPIRE (604800)  // one week
+#define KEY_LIFETIME_IN_SECONDS (60 * 60 * 24 * 365 * CONFIG_UBIRCH_KEY_LIFETIME_YEARS)
+#define KEY_UPDATE_BEFORE_EXPIRE_IN_SECONDS (60 * 60 * 24 * 7) // one week
+
+#define STR(x) #x
+#define VALUE_STRING(x) STR(x)
+#pragma message ("Key lifetime at creation and update is set to " \
+        VALUE_STRING(CONFIG_UBIRCH_KEY_LIFETIME_YEARS) " year(s)")
 
 static const char *TAG = "KEYSTORE";
 
@@ -171,7 +176,7 @@ void create_keys(void) {
 
     key_status_t key_status = {
         .keys_registered = 0,
-        .next_update = info.validNotAfter - KEY_UPDATE_BEFORE_EXPIRE
+        .next_update = info.validNotAfter - KEY_UPDATE_BEFORE_EXPIRE_IN_SECONDS
     };
     if (kv_store("key_storage", "key_status", &key_status, sizeof(key_status)) != ESP_OK) {
         ESP_LOGW(TAG, "failed to store key status in flash");
@@ -327,7 +332,7 @@ int update_keys(void) {
 
     key_status_t key_status = {
         .keys_registered = 1,
-        .next_update = now + KEY_LIFETIME_IN_SECONDS - KEY_UPDATE_BEFORE_EXPIRE
+        .next_update = now + KEY_LIFETIME_IN_SECONDS - KEY_UPDATE_BEFORE_EXPIRE_IN_SECONDS
     };
     if (kv_store("key_storage", "key_status", &key_status, sizeof(key_status)) != ESP_OK) {
         ESP_LOGW(TAG, "failed to write status to flash");

--- a/key_handling.h
+++ b/key_handling.h
@@ -37,6 +37,7 @@ extern "C" {
 // length of base64 string is ceil(number_of_bytes / 3) * 4
 // to get ceil for value / 3 (value >= 0) we use (value + 2) / 3
 #define PUBLICKEY_BASE64_STRING_LENGTH (((crypto_sign_PUBLICKEYBYTES + 2) / 3) * 4)
+#define BYTES_LENGTH_TO_BASE64_STRING_LENGTH(__len) (((__len + 2) / 3) * 4)
 
 extern unsigned char server_pub_key[crypto_sign_PUBLICKEYBYTES];
 
@@ -55,6 +56,13 @@ void create_keys(void);
  * This function can only be executed, if a network connection is available.
  */
 void register_keys(void);
+
+/*!
+ * Update the Keys in the backend.
+ *
+ * This function can only be executed, if a network connection is available.
+ */
+int update_keys(void);
 
 /*!
  * Check the current key status.

--- a/key_handling.h
+++ b/key_handling.h
@@ -69,7 +69,12 @@ int update_keys(void);
  *
  * If no keys are present, create new keys. The key registration has to be executed separately.
  */
-void check_key_status(void);
+#define KEY_STATUS_ERR (-1)
+#define KEY_STATUS_OK (0)
+#define KEY_STATUS_NO_KEYS (1)
+#define KEY_STATUS_NOT_REGISTERED (2)
+#define KEY_STATUS_UPDATE_NEEDED (3)
+int check_key_status(void);
 
 /*!
  * Set backend public key.

--- a/test/test.c
+++ b/test/test.c
@@ -82,3 +82,11 @@ TEST_CASE("try to get backend key in base64 format into buffer that is too small
     TEST_ASSERT_EQUAL_INT(ESP_FAIL, get_backend_public_key((char*)buffer2, sizeof(buffer2)));
     printf("%s\n", buffer2);
 }
+
+TEST_CASE("key update", "[key handling]") {
+    if (load_keys() != ESP_OK) {
+        create_keys();
+    }
+    TEST_ASSERT_EQUAL_INT(ESP_OK, load_keys());
+    update_keys();
+}


### PR DESCRIPTION
This PR adds:
- a key updating function, that gets a "key update certificate" from ubirch-protocol (`json_pack_key_update`) signs it and sends it to the backend
- a key-registered marker into nvs-storage (to avoid multiple registrations of a key)